### PR TITLE
Added Options to Choose Directory to save the pdf

### DIFF
--- a/lib/PDFConversion.dart
+++ b/lib/PDFConversion.dart
@@ -181,7 +181,8 @@ class _PDFConversion extends State<PDFConversion> {
     await savePdf();
     //Documents.add(document);
     Directory documentDirectory = await getApplicationDocumentsDirectory();
-    documentDirectory = pickedDirectory;
+    
+    if (pickedDirectory!=null) documentDirectory = pickedDirectory;
 
     String documentPath = documentDirectory.path;
     //document.documentPath = documentPath;

--- a/lib/PDFConversion.dart
+++ b/lib/PDFConversion.dart
@@ -1,7 +1,9 @@
 import 'dart:io';
 import 'package:flutter/cupertino.dart';
 import 'package:flutter/material.dart';
+import 'package:folder_picker/folder_picker.dart';
 import 'package:pdf/pdf.dart';
+import 'package:permission/permission.dart';
 import 'Providers/ImageList.dart';
 import 'package:path_provider/path_provider.dart';
 import 'package:pdf/widgets.dart' as pw;
@@ -19,6 +21,8 @@ class _PDFConversion extends State<PDFConversion> {
   //DocumentObject document;
   var name;
   final myController = TextEditingController();
+  Directory externalDirectory;
+  Directory pickedDirectory;
 
   @override
   void dispose() {
@@ -63,6 +67,12 @@ class _PDFConversion extends State<PDFConversion> {
   }
 
   @override
+  void initState() {
+    // TODO: implement initState
+    super.initState();
+  }
+
+  @override
   Widget build(BuildContext context) {
     return Scaffold(
       backgroundColor: Colors.white,
@@ -72,6 +82,31 @@ class _PDFConversion extends State<PDFConversion> {
           'Name Your PDF',
           style: TextStyle(color: Colors.white, fontSize: 22),
         ),
+        actions: [
+          GestureDetector(
+            child: Center(
+              child: Text(
+                "Choose Directory to save",
+              ),
+            ),
+            onTap: () async {
+              await getPermissions();
+              await getStorage();
+              Navigator.of(context)
+                  .push<FolderPickerPage>(MaterialPageRoute(
+                      builder: (BuildContext context) {
+                return FolderPickerPage(
+                    rootDirectory: externalDirectory,
+                    action: (BuildContext context,
+                        Directory folder) async {
+                      print("Picked directory $folder");
+                      setState(() => pickedDirectory = folder);
+                      Navigator.of(context).pop();
+                    });
+              }));
+            },
+          )
+        ],
       ),
       body: Padding(
         padding: const EdgeInsets.all(16.0),
@@ -114,17 +149,44 @@ class _PDFConversion extends State<PDFConversion> {
     );
   }
 
+  Future<void> getPermissions() async {
+    final permissions =
+        await Permission.getPermissionsStatus([PermissionName.Storage]);
+    var request = true;
+    switch (permissions[0].permissionStatus) {
+      case PermissionStatus.allow:
+        request = false;
+        break;
+      case PermissionStatus.always:
+        request = false;
+        break;
+      default:
+    }
+    if (request) {
+      await Permission.requestPermissions([PermissionName.Storage]);
+    }
+  }
+
+  Future<void> getStorage() async {
+    final directory = await getExternalStorageDirectory();
+    setState(() => externalDirectory = directory);
+  }
+
   Future<void> _pushSaved() async {
     name = Text(myController.text).data;
+
+    
     //document.name = name;
     writeOnPdf();
     await savePdf();
     //Documents.add(document);
     Directory documentDirectory = await getApplicationDocumentsDirectory();
+    documentDirectory = pickedDirectory;
 
     String documentPath = documentDirectory.path;
     //document.documentPath = documentPath;
     String fullPath = "$documentPath" + "/${name}" + ".pdf";
+    print(fullPath);
 
     Navigator.push(
         context,

--- a/pubspec.lock
+++ b/pubspec.lock
@@ -113,6 +113,20 @@ packages:
       url: "https://pub.dartlang.org"
     source: hosted
     version: "5.2.1"
+  filesize:
+    dependency: transitive
+    description:
+      name: filesize
+      url: "https://pub.dartlang.org"
+    source: hosted
+    version: "1.0.4"
+  filex:
+    dependency: transitive
+    description:
+      name: filex
+      url: "https://pub.dartlang.org"
+    source: hosted
+    version: "0.2.2"
   flutter:
     dependency: "direct main"
     description: flutter
@@ -132,11 +146,25 @@ packages:
       url: "https://pub.dartlang.org"
     source: hosted
     version: "1.0.11"
+  flutter_slidable:
+    dependency: transitive
+    description:
+      name: flutter_slidable
+      url: "https://pub.dartlang.org"
+    source: hosted
+    version: "0.5.7"
   flutter_test:
     dependency: "direct dev"
     description: flutter
     source: sdk
     version: "0.0.0"
+  folder_picker:
+    dependency: "direct main"
+    description:
+      name: folder_picker
+      url: "https://pub.dartlang.org"
+    source: hosted
+    version: "0.3.0"
   http:
     dependency: transitive
     description:
@@ -213,7 +241,7 @@ packages:
       name: open_file
       url: "https://pub.dartlang.org"
     source: hosted
-    version: "3.0.3"
+    version: "2.1.1"
   page_transition:
     dependency: transitive
     description:
@@ -284,6 +312,13 @@ packages:
       url: "https://pub.dartlang.org"
     source: hosted
     version: "1.9.2"
+  permission:
+    dependency: "direct main"
+    description:
+      name: permission
+      url: "https://pub.dartlang.org"
+    source: hosted
+    version: "0.1.7"
   petitparser:
     dependency: transitive
     description:
@@ -333,6 +368,13 @@ packages:
       url: "https://pub.dartlang.org"
     source: hosted
     version: "1.3.0"
+  rxdart:
+    dependency: transitive
+    description:
+      name: rxdart
+      url: "https://pub.dartlang.org"
+    source: hosted
+    version: "0.22.6"
   sky_engine:
     dependency: transitive
     description: flutter

--- a/pubspec.yaml
+++ b/pubspec.yaml
@@ -3,7 +3,7 @@ description: A new Flutter project.
 
 # The following line prevents the package from being accidentally published to
 # pub.dev using `pub publish`. This is preferred for private packages.
-publish_to: 'none' # Remove this line if you wish to publish to pub.dev
+publish_to: "none" # Remove this line if you wish to publish to pub.dev
 
 # The following defines the version and build number for your application.
 # A version number is three numbers separated by dots, like 1.2.43
@@ -23,38 +23,30 @@ environment:
 dependencies:
   flutter:
     sdk: flutter
-    
-
-
-
-
-  # The following adds the Cupertino Icons font to your application.
-  # Use with the CupertinoIcons class for iOS style icons.
   animated_splash_screen: ^1.0.1+2
-  splashscreen: ^1.3.5
-  image_picker: ^0.6.7+21
-  image_cropper: ^1.3.1  
   cupertino_icons: ^0.1.3
-  photofilters: ^2.0.1
-  open_file: ^3.0.3
-  provider: ^4.3.3
-  pdf: ^1.9.0
-  #image: ^2.1.4
-  path_provider: ^1.6.27
   flutter_full_pdf_viewer: ^1.0.6
+  folder_picker: ^0.3.0
+  image_cropper: ^1.3.1
+  image_picker: ^0.6.7+21
+  open_file: ^2.0.3
   path: ^1.7.0
-  storage_path: ^0.2.0
+  path_provider: ^1.6.27
+  pdf: ^1.9.0
+  permission: ^0.1.7
+  photofilters: ^2.0.1
+  provider: ^4.3.3
   source_span: ^1.7.0
+  splashscreen: ^1.3.5
+  storage_path: ^0.2.0
 dev_dependencies:
   flutter_test:
     sdk: flutter
 
 # For information on the generic Dart part of this file, see the
 # following page: https://dart.dev/tools/pub/pubspec
-
 # The following section is specific to Flutter.
 flutter:
-
   # The following line ensures that the Material Icons font is
   # included with your application, so that you can use the icons in
   # the material Icons class.
@@ -66,13 +58,10 @@ flutter:
     - assets/images/
   #   - images/a_dot_burr.jpeg
   #   - images/a_dot_ham.jpeg
-
   # An image asset can refer to one or more resolution-specific "variants", see
   # https://flutter.dev/assets-and-images/#resolution-aware.
-
   # For details regarding adding assets from package dependencies, see
   # https://flutter.dev/assets-and-images/#from-packages
-
   # To add custom fonts to your application, add a fonts section here,
   # in this "flutter" section. Each entry in this list should have a
   # "family" key with the font family name, and a "fonts" key with a
@@ -92,6 +81,5 @@ flutter:
   #
   # For details regarding fonts from package dependencies,
   # see https://flutter.dev/custom-fonts/#from-packages
-
 dependencies_overrides:
   collection: ^1.14.12


### PR DESCRIPTION
I have used the package 'folder_picker' to choose the directory where the user wants to save the pdf , and based on the chosen directory the file path of the pdf is set.

I have added the 'Choose Directory to Save' option in the PDFConversion.dart file where the user can select the path before saving the pdf.

Fixes Issue #45 