### PR TITLE
Fixed image size issue in Imageview.dart

### DIFF
--- a/lib/Imageview.dart
+++ b/lib/Imageview.dart
@@ -89,7 +89,6 @@ class _ImageviewState extends State<Imageview> {
                   padding: const EdgeInsets.fromLTRB(20, 10, 20, 20),
                   child: Image.file(
                     files[index],
-                    fit: BoxFit.fill,
                   ),
                 ),
               ),


### PR DESCRIPTION
A small PR, deleting one line fixed the issue. Now the image size is consistent in both the image editing screens. Closes #89.