### PR TITLE
Replaced all PNGs with SVGs

### DIFF
--- a/assets/doclenselightsmall.svg
+++ b/assets/doclenselightsmall.svg
@@ -1,1 +1,13 @@
-<svg id="Layer_1" data-name="Layer 1" xmlns="http://www.w3.org/2000/svg" viewBox="0 0 100.32 98.2"><defs><style>.cls-1,.cls-2{fill:none;stroke:#1f9fff;stroke-miterlimit:10;stroke-width:11px;}.cls-2{stroke-linecap:round;}</style></defs><title>doclenselightsmall</title><polyline class="cls-1" points="66.7 5.5 94.83 5.5 94.83 31.18"/><polyline class="cls-1" points="33.63 92.7 5.5 92.7 5.5 67.02"/><polyline class="cls-1" points="66.7 92.7 94.83 92.7 94.83 67.02"/><polyline class="cls-1" points="33.63 5.5 5.5 5.5 5.5 31.18"/><line class="cls-2" x1="22.37" y1="26.75" x2="78.32" y2="26.75"/><line class="cls-2" x1="22.37" y1="48.72" x2="78.32" y2="48.72"/><line class="cls-2" x1="22.37" y1="70.7" x2="78.32" y2="70.7"/></svg>
+<svg viewBox="0 0 100.32 98.2" xmlns="http://www.w3.org/2000/svg">
+    <g fill="none" stroke="#1f9fff" stroke-miterlimit="10" stroke-width="11">
+        <path d="m66.7 5.5h28.13v25.68"/>
+        <path d="m33.63 92.7h-28.13v-25.68"/>
+        <path d="m66.7 92.7h28.13v-25.68"/>
+        <path d="m33.63 5.5h-28.13v25.68"/>
+        <g stroke-linecap="round">
+            <path d="m22.37 26.75h55.95"/>
+            <path d="m22.37 48.72h55.95"/>
+            <path d="m22.37 70.7h55.95"/>
+        </g>
+    </g>
+</svg>

--- a/assets/doclensewhite.svg
+++ b/assets/doclensewhite.svg
@@ -1,1 +1,12 @@
-<svg id="Layer_1" data-name="Layer 1" xmlns="http://www.w3.org/2000/svg" viewBox="0 0 623.2 151.25"><defs><style>.cls-1,.cls-2{fill:none;stroke:#fff;stroke-miterlimit:10;stroke-width:11px;}.cls-2{stroke-linecap:round;}.cls-3{font-size:104.78px;fill:#fff;font-family:Poppins-SemiBold, Poppins;font-weight:600;}</style></defs><title>doclensewhite</title><polyline class="cls-1" points="66.7 12.75 94.83 12.75 94.83 38.43"/><polyline class="cls-1" points="33.63 99.95 5.5 99.95 5.5 74.27"/><polyline class="cls-1" points="66.7 99.95 94.83 99.95 94.83 74.27"/><polyline class="cls-1" points="33.63 12.75 5.5 12.75 5.5 38.43"/><line class="cls-2" x1="22.37" y1="34" x2="78.32" y2="34"/><line class="cls-2" x1="22.37" y1="55.97" x2="78.32" y2="55.97"/><line class="cls-2" x1="22.37" y1="77.95" x2="78.32" y2="77.95"/><text class="cls-3" transform="translate(137.45 89.11)">doclense</text></svg>
+<svg viewBox="0 0 623.2 151.25" xmlns="http://www.w3.org/2000/svg">
+    <g fill="none" stroke="#fff" stroke-miterlimit="10" stroke-width="11">
+        <path d="m66.7 12.75h28.13v25.68"/>
+        <path d="m33.63 99.95h-28.13v-25.68"/>
+        <path d="m66.7 99.95h28.13v-25.68"/>
+        <path d="m33.63 12.75h-28.13v25.68"/>
+        <path d="m22.37 34h55.95" stroke-linecap="round"/>
+        <path d="m22.37 55.97h55.95" stroke-linecap="round"/>
+        <path d="m22.37 77.95h55.95" stroke-linecap="round"/>
+    </g>
+    <text fill="#fff" font-family="Poppins-SemiBold, Poppins" font-size="104.78" font-weight="600" transform="translate(137.45 89.11)">doclense</text>
+</svg>

--- a/assets/doclensewhitesmall.svg
+++ b/assets/doclensewhitesmall.svg
@@ -1,1 +1,14 @@
-<svg id="Layer_1" data-name="Layer 1" xmlns="http://www.w3.org/2000/svg" viewBox="0 0 100.32 98.2"><defs><style>.cls-1,.cls-2{fill:none;stroke:#fff;stroke-miterlimit:10;stroke-width:11px;}.cls-2{stroke-linecap:round;}</style></defs><title>doclensewhitesmall</title><polyline class="cls-1" points="66.7 5.5 94.83 5.5 94.83 31.18"/><polyline class="cls-1" points="33.63 92.7 5.5 92.7 5.5 67.02"/><polyline class="cls-1" points="66.7 92.7 94.83 92.7 94.83 67.02"/><polyline class="cls-1" points="33.63 5.5 5.5 5.5 5.5 31.18"/><line class="cls-2" x1="22.37" y1="26.75" x2="78.32" y2="26.75"/><line class="cls-2" x1="22.37" y1="48.72" x2="78.32" y2="48.72"/><line class="cls-2" x1="22.37" y1="70.7" x2="78.32" y2="70.7"/></svg>
+<svg viewBox="0 0 100.32 98.2" xmlns="http://www.w3.org/2000/svg">
+    <g fill="none" stroke="#fff" stroke-miterlimit="10" stroke-width="11">
+        <path d="m66.7 5.5h28.13v25.68"/>
+        <path d="m33.63 92.7h-28.13v-25.68"/>
+        <path d="m66.7 92.7h28.13v-25.68"/>
+        <path d="m33.63 5.5h-28.13v25.68"/>
+        <g stroke-linecap="round">
+            <path d="m22.37 26.75h55.95"/>
+            <path d="m22.37 48.72h55.95"/>
+            <path d="m22.37 70.7h55.95"/>
+        </g>
+    </g>
+</svg>
+

--- a/assets/images/doclenselight.svg
+++ b/assets/images/doclenselight.svg
@@ -1,1 +1,12 @@
-<svg id="Layer_1" data-name="Layer 1" xmlns="http://www.w3.org/2000/svg" viewBox="0 0 623.2 151.25"><defs><style>.cls-1,.cls-2{fill:none;stroke:#1f9fff;stroke-miterlimit:10;stroke-width:11px;}.cls-2{stroke-linecap:round;}.cls-3{font-size:104.78px;fill:#232323;font-family:Poppins-SemiBold, Poppins;font-weight:600;}</style></defs><title>doclense.lightsvg</title><polyline class="cls-1" points="66.7 12.75 94.83 12.75 94.83 38.43"/><polyline class="cls-1" points="33.63 99.95 5.5 99.95 5.5 74.27"/><polyline class="cls-1" points="66.7 99.95 94.83 99.95 94.83 74.27"/><polyline class="cls-1" points="33.63 12.75 5.5 12.75 5.5 38.43"/><line class="cls-2" x1="22.37" y1="34" x2="78.32" y2="34"/><line class="cls-2" x1="22.37" y1="55.97" x2="78.32" y2="55.97"/><line class="cls-2" x1="22.37" y1="77.95" x2="78.32" y2="77.95"/><text class="cls-3" transform="translate(137.45 89.11)">doclense</text></svg>
+<svg viewBox="0 0 623.2 151.25" xmlns="http://www.w3.org/2000/svg">
+    <g fill="none" stroke="#1f9fff" stroke-miterlimit="10" stroke-width="11">
+        <path d="m66.7 12.75h28.13v25.68"/>
+        <path d="m33.63 99.95h-28.13v-25.68"/>
+        <path d="m66.7 99.95h28.13v-25.68"/>
+        <path d="m33.63 12.75h-28.13v25.68"/>
+        <path d="m22.37 34h55.95" stroke-linecap="round"/>
+        <path d="m22.37 55.97h55.95" stroke-linecap="round"/>
+        <path d="m22.37 77.95h55.95" stroke-linecap="round"/>
+    </g>
+    <text fill="#232323" font-family="Poppins-SemiBold, Poppins" font-size="104.78" font-weight="600" transform="translate(137.45 89.11)">doclense</text>
+</svg>

--- a/lib/About.dart
+++ b/lib/About.dart
@@ -2,6 +2,7 @@ import 'package:doclense/MainDrawer.dart';
 import 'package:doclense/Providers/ThemeProvider.dart';
 import 'package:flutter/cupertino.dart';
 import 'package:flutter/material.dart';
+import 'package:flutter_svg/flutter_svg.dart';
 import 'package:provider/provider.dart';
 
 class About extends StatelessWidget {
@@ -22,15 +23,20 @@ class About extends StatelessWidget {
           mainAxisAlignment: MainAxisAlignment.start,
           children: <Widget>[
             themeChange.darkTheme ?
-            Image.asset(
-              'assets/images/doclenseDarkCropped.jpg',
-              height: 150,
-              width: MediaQuery.of(context).size.width,)
+            Padding(
+              padding: const EdgeInsets.fromLTRB(40, 4, 4, 0),
+              child: SvgPicture.asset(
+                'assets/doclensewhite.svg',
+              ),
+            )
                 :
-            Image.asset(
-              'assets/images/logos.png',
-              width: 300,
-              height: 100,
+            Padding(
+              padding: const EdgeInsets.fromLTRB(40, 4, 4, 0),
+              child: SvgPicture.asset(
+                'assets/images/doclenselight.svg',
+                // width: 300,
+                // height: 100,
+              ),
             ),
             Padding(
               padding: const EdgeInsets.fromLTRB(10, 30, 10, 10),

--- a/lib/MainDrawer.dart
+++ b/lib/MainDrawer.dart
@@ -21,7 +21,7 @@ class MainDrawer extends StatelessWidget {
           Container(
             width: double.infinity,
             padding: EdgeInsets.all(20),
-            color: Colors.blue[600],
+            color: themeChange.darkTheme ? Colors.black : Colors.white10,
             child: Center(
                 child: Column(
                   children: <Widget>[
@@ -29,23 +29,23 @@ class MainDrawer extends StatelessWidget {
                       width: 100,
                       height: 180,
                       child: CircleAvatar(
-                        backgroundColor: themeChange.darkTheme ? Colors.black : Colors.white,
+                        backgroundColor: themeChange.darkTheme ? Colors.black : Colors.white10,
                         radius: 60,
                         child: themeChange.darkTheme ?
                         SvgPicture.asset(
                           'assets/doclensewhitesmall.svg',
-                          height: 70,
+                          height: 100,
                         ) :
                         SvgPicture.asset(
                           'assets/doclenselightsmall.svg',
-                          height: 70,
+                          height: 100,
                         ),
                       ),
                     ),
                     Text(
                       "One Place For All \n Your Documents!",
-                      style: TextStyle(fontSize: 20, color: Colors.white),
-                    )
+                      style: TextStyle(fontSize: 20),
+                    ),
                   ],
                 )),
           ),

--- a/lib/MainDrawer.dart
+++ b/lib/MainDrawer.dart
@@ -1,5 +1,6 @@
 import 'package:doclense/settings.dart';
 import 'package:flutter/material.dart';
+import 'package:flutter_svg/flutter_svg.dart';
 import 'package:provider/provider.dart';
 import 'Home.dart';
 import 'About.dart';
@@ -28,10 +29,16 @@ class MainDrawer extends StatelessWidget {
                       width: 100,
                       height: 180,
                       child: CircleAvatar(
-                        backgroundColor: Colors.white,
+                        backgroundColor: themeChange.darkTheme ? Colors.black : Colors.white,
                         radius: 60,
-                        child: Image.asset(
-                          'assets/images/scanlogo.png',
+                        child: themeChange.darkTheme ?
+                        SvgPicture.asset(
+                          'assets/doclensewhitesmall.svg',
+                          height: 70,
+                        ) :
+                        SvgPicture.asset(
+                          'assets/doclenselightsmall.svg',
+                          height: 70,
                         ),
                       ),
                     ),
@@ -74,7 +81,7 @@ class MainDrawer extends StatelessWidget {
             onTap: () {
               Navigator.of(context).pop();
               Navigator.push(
-                  context, PageRouteBuilder(
+                context, PageRouteBuilder(
                 pageBuilder: (c, a1, a2) => About(),
                 transitionsBuilder: (c, anim, a2, child) =>
                     FadeTransition(opacity: anim, child: child),

--- a/lib/main.dart
+++ b/lib/main.dart
@@ -1,6 +1,7 @@
 import 'package:doclense/Home.dart';
 import 'package:flutter/material.dart';
 import 'package:animated_splash_screen/animated_splash_screen.dart';
+import 'package:flutter_svg/flutter_svg.dart';
 import 'package:introduction_screen/introduction_screen.dart';
 import 'dart:ui';
 import 'package:doclense/Providers/ThemeProvider.dart';
@@ -68,8 +69,15 @@ class _MyAppState extends State<MyApp> {
                   backgroundColor: themeChangeProvider.darkTheme ? Colors
                       .grey[900] : Colors.white,
                   splash: themeChangeProvider.darkTheme ?
-                  Image.asset('assets/images/doclenseDarkCropped.jpg')
-                      : Image.asset('assets/images/logos.png'),
+                  Padding(
+                    padding: const EdgeInsets.fromLTRB(40, 4, 4, 0),
+                    child: SvgPicture.asset('assets/doclensewhite.svg'),
+                  )
+                      :
+                  Padding(
+                    padding: const EdgeInsets.fromLTRB(40, 4, 4, 0),
+                    child: SvgPicture.asset('assets/images/doclenselight.svg'),
+                  ),
                   nextScreen: FutureBuilder(
                       future: checkFirstTime(),
                       builder: (context, snapshot) {

--- a/pubspec.yaml
+++ b/pubspec.yaml
@@ -46,7 +46,8 @@ dependencies:
   url_launcher: ^5.7.10
   folder_picker: ^0.3.0
   introduction_screen: ^1.0.9
-  # open_file: ^3.0.3
+  flutter_svg: 0.18.0
+
 dev_dependencies:
   flutter_test:
     sdk: flutter
@@ -65,6 +66,7 @@ flutter:
   # assets:
   assets:
     - assets/images/
+    - assets/
   #   - images/a_dot_burr.jpeg
   #   - images/a_dot_ham.jpeg
   # An image asset can refer to one or more resolution-specific "variants", see


### PR DESCRIPTION
Closes #94 
PNGs in all the screens have been replaced with SVGs. This took me more time than was expected and the reasons for that are listed below.

## Some thing to note
1. The most recent version of flutter_svg plugin is not compatible with the most recent version of flutter on stable channel, so I had to use a previous version of the same plugin.
2. flutter_svg somehow does not support ```<style>``` tag which was present in all the SVGs, if the ```<style>``` tag is used, the console throws an error and the SVG is not visible in the app. I got the first SVG re-written by someone else (I am not good with tags and CSS) and after that I found [an open source software](https://github.com/razrfalcon/svgcleaner) (this was suggested to me by the owner of flutter_svg plugin) that re-writes the whole SVG and makes it compatible with the plugin.

A suggestion - Maybe we can add some information in the README or in Contributing guidelines about this, that if someone wants to modify or add any SVG he/she must pass it through the software (mentioned above) first and then add it to the codebase to avoid errors.

Lastly please review and add the necessary tags for MWoC before merging.

Thank you:)

## Screenshots

A similar thing is also done in the splash screen.

![Screenshot_1613113602](https://user-images.githubusercontent.com/74055102/107741251-d2f50f00-6d32-11eb-8cd4-010f0c7f4619.png)


![Screenshot_1613113556](https://user-images.githubusercontent.com/74055102/107741254-d4bed280-6d32-11eb-8b12-d9d884724370.png)


![Screenshot_1613113610](https://user-images.githubusercontent.com/74055102/107741259-d6889600-6d32-11eb-8cd6-bf675ab06793.png)


![Screenshot_1613113615](https://user-images.githubusercontent.com/74055102/107741262-d7b9c300-6d32-11eb-8e29-053837e87451.png)


