### PR TITLE
Fixed the issue with endless stacking of screens

### DIFF
--- a/lib/Home.dart
+++ b/lib/Home.dart
@@ -1,3 +1,4 @@
+import 'dart:async';
 import 'package:flutter/cupertino.dart';
 import 'package:flutter/material.dart';
 import 'package:hive/hive.dart';
@@ -59,7 +60,6 @@ class _HomeState extends State<Home> {
   @override
   void initState() {
     super.initState();
-
     // setSharedPreferences().then((value) {
     //   savedPdfs = value;
     //   print('Saved : $savedPdfs');

--- a/lib/MainDrawer.dart
+++ b/lib/MainDrawer.dart
@@ -57,14 +57,7 @@ class MainDrawer extends StatelessWidget {
             ),
             ListTile(
                 onTap: () {
-                  Navigator.of(context).pop();
-                  Navigator.push(
-                      context, PageRouteBuilder(
-                    pageBuilder: (c, a1, a2) => Home(),
-                    transitionsBuilder: (c, anim, a2, child) =>
-                        FadeTransition(opacity: anim, child: child),
-                    // transitionDuration: Duration(milliseconds: 1000),
-                  ));
+                  Navigator.of(context).popUntil((route) => route.isFirst);
                 },
                 leading: Icon(Icons.home),
                 title: Text(
@@ -80,6 +73,7 @@ class MainDrawer extends StatelessWidget {
             ),
             ListTile(
               onTap: () {
+                Navigator.of(context).pop();
                 Navigator.push(context,
                   PageRouteBuilder(
                     pageBuilder: (c, a1, a2) => SettingsScreen(),

--- a/lib/PDFPreviewScreen.dart
+++ b/lib/PDFPreviewScreen.dart
@@ -24,13 +24,7 @@ class _PdfPreviewScreenState extends State<PdfPreviewScreen> {
 
   homePageTimer() {
     Timer(Duration(seconds: 0), () async {
-      Navigator.pushReplacement(
-          context, PageRouteBuilder(
-        pageBuilder: (c, a1, a2) => Home(),
-        transitionsBuilder: (c, anim, a2, child) =>
-            FadeTransition(opacity: anim, child: child),
-        // transitionDuration: Duration(milliseconds: 1000),
-      ));  // pushing HomePage()
+      Navigator.of(context).popUntil((route) => route.isFirst);
     });
   }
 

--- a/lib/multi_select_delete.dart
+++ b/lib/multi_select_delete.dart
@@ -233,17 +233,13 @@ class _multiDeleteState extends State<multiDelete> {
                         FadeTransition(opacity: anim, child: child),
                     // transitionDuration: Duration(milliseconds: 2000),
                   ));
-                  // MaterialPageRoute(
-                  //     builder: (context) => PDFConversion(widget.imageList)));
+              // MaterialPageRoute(
+              //     builder: (context) => PDFConversion(widget.imageList)));
             }),
         IconButton(
             icon: Icon(Icons.home),
             onPressed: () {
-              Navigator.push(
-                  context, PageRouteBuilder(
-                  pageBuilder: (c, a1, a2) => Home(),
-              transitionsBuilder: (c, anim, a2, child) =>
-              FadeTransition(opacity: anim, child: child)));
+              Navigator.of(context).popUntil((route) => route.isFirst);
             })
       ],
     );


### PR DESCRIPTION
Closes #110 

I explored about this problem a lot and instead of using the method mentioned by me in the issue, I used a method which is a lot simpler. Now when the user anywhere presses any button which leads him to the home screen, all the existing screens (except the original home screen) are popped instead of pushing the home screen above to create an endless stack. You can stack as many screens you want but once you press the home button, the stack is cleared and has only the original home screen in it.

For example, one such situation where this problem was faced was after creating the PDF- Now after creating the PDF, the home screen is not pushed on the already existing screens ( which are home, crop, filter, multiselect, PDFview screens), rather, all these existing screens are popped to bring the user to the original home screen which makes the app more efficient and bug free.

Please review and let me know if any changes are required. Thank you!

(MWoC and CWoC participant)