### PR TITLE
After clicking the home button in multi_select_delete, all the images are discarded 

### DIFF
--- a/lib/multi_select_delete.dart
+++ b/lib/multi_select_delete.dart
@@ -95,6 +95,52 @@ class _multiDeleteState extends State<multiDelete> {
         });
   }
 
+  Future<void> _showChoiceDialog_home(BuildContext context) {
+    return showDialog(
+        context: context,
+        builder: (BuildContext context) {
+          return AlertDialog(
+            backgroundColor: Colors.blueGrey[800],
+            title: Text(
+              "All your progress will be lost.\nDo you want to go back to home?",
+              textAlign: TextAlign.center,
+              style: TextStyle(color: Colors.white),
+            ),
+            content: SingleChildScrollView(
+              child: ListBody(
+                children: <Widget>[
+                  GestureDetector(
+                    child: Text(
+                      "Yes",
+                      textAlign: TextAlign.center,
+                      style: TextStyle(color: Colors.white),
+                    ),
+                    onTap: () {
+
+                      Navigator.of(context).pop();
+                      Navigator.of(context).popUntil((route) => route.isFirst);
+                    },
+                  ),
+                  Padding(
+                    padding: EdgeInsets.all(10),
+                  ),
+                  GestureDetector(
+                    child: Text(
+                      "No",
+                      textAlign: TextAlign.center,
+                      style: TextStyle(color: Colors.white),
+                    ),
+                    onTap: () {
+                      Navigator.of(context).pop();
+                    },
+                  ),
+                ],
+              ),
+            ),
+          );
+        });
+  }
+
   _openGallery() async {
     var picture = await ImagePicker.pickImage(source: ImageSource.gallery);
     this.setState(() {

--- a/lib/multi_select_delete.dart
+++ b/lib/multi_select_delete.dart
@@ -116,7 +116,7 @@ class _multiDeleteState extends State<multiDelete> {
                       style: TextStyle(color: Colors.white),
                     ),
                     onTap: () {
-                      for (int i = 0; i < widget.imageList.length(); i++) {
+                      for (int i = 0; i < itemList.length; i++) {
                         print('i = $i');
                         print(widget.imageList.imagelist.length);
                         int idx = widget.imageList.imagelist.indexOf(

--- a/lib/multi_select_delete.dart
+++ b/lib/multi_select_delete.dart
@@ -116,7 +116,16 @@ class _multiDeleteState extends State<multiDelete> {
                       style: TextStyle(color: Colors.white),
                     ),
                     onTap: () {
-
+                      for (int i = 0; i < widget.imageList.length(); i++) {
+                        print('i = $i');
+                        print(widget.imageList.imagelist.length);
+                        int idx = widget.imageList.imagelist.indexOf(
+                            itemList[itemList.indexOf(itemList[i])]
+                                .imageUrl);
+                        widget.imageList.imagelist.removeAt(idx);
+                        widget.imageList.imagepath.removeAt(idx);
+                        itemList.remove(idx);
+                      }
                       Navigator.of(ctx).pop();
                       Navigator.of(context).popUntil((route) => route.isFirst);
                     },

--- a/lib/multi_select_delete.dart
+++ b/lib/multi_select_delete.dart
@@ -98,7 +98,7 @@ class _multiDeleteState extends State<multiDelete> {
   Future<void> _showChoiceDialog_home(BuildContext context) {
     return showDialog(
         context: context,
-        builder: (BuildContext context) {
+        builder: (BuildContext ctx) {
           return AlertDialog(
             backgroundColor: Colors.blueGrey[800],
             title: Text(
@@ -117,7 +117,7 @@ class _multiDeleteState extends State<multiDelete> {
                     ),
                     onTap: () {
 
-                      Navigator.of(context).pop();
+                      Navigator.of(ctx).pop();
                       Navigator.of(context).popUntil((route) => route.isFirst);
                     },
                   ),
@@ -131,7 +131,7 @@ class _multiDeleteState extends State<multiDelete> {
                       style: TextStyle(color: Colors.white),
                     ),
                     onTap: () {
-                      Navigator.of(context).pop();
+                      Navigator.of(ctx).pop();
                     },
                   ),
                 ],
@@ -285,7 +285,7 @@ class _multiDeleteState extends State<multiDelete> {
         IconButton(
             icon: Icon(Icons.home),
             onPressed: () {
-              Navigator.of(context).popUntil((route) => route.isFirst);
+              _showChoiceDialog_home(context);
             })
       ],
     );


### PR DESCRIPTION
Fixes #118 

After pressing the home button, user is presented with a confirmation/warning dialogue. If he chooses to press yes then all the present images are discarded and he is redirected to the home screen. 

Now when he tries to create another PDF from there, there will be no images present from the previous PDF creation process which he stopped in the middle because he didn't want to proceed.

Please review and let me know if any changes are required. Thank you!

(MWoC and CWoC participant)

