### PR TITLE
Fixed the bug associated with going back without clicking a picture in multi_select_delete page

### DIFF
--- a/lib/multi_select_delete.dart
+++ b/lib/multi_select_delete.dart
@@ -109,8 +109,10 @@ class _multiDeleteState extends State<multiDelete> {
     this.setState(() {
       imageFile = picture;
     });
-    Navigator.of(context).push(MaterialPageRoute(
-        builder: (context) => Imageview(imageFile, widget.imageList)));
+    if (imageFile != null) {
+      Navigator.of(context).push(MaterialPageRoute(
+          builder: (context) => Imageview(imageFile, widget.imageList)));
+    }
   }
 
   Future<void> _showChoiceDialog_add(BuildContext context) {


### PR DESCRIPTION
Fixes #122 

Now the code checks if the user clicked a picture or not, if the user did then it pushes a new screen (Imageview.dart) like it did before but if the user didn't then it performs nothing and brings the user back to multi_select_delete page. Please review and let me know if any changes are required. Thank you!

(MWoC and CWoC participant)