### PR TITLE
Fixed the issue with Intro slider appearing again and again for first time users

### DIFF
--- a/lib/main.dart
+++ b/lib/main.dart
@@ -173,16 +173,22 @@ class _MyAppState extends State<MyApp> {
                               ],
                               onDone: () {
                                 setFirstTime();
-                                Navigator.push(context, MaterialPageRoute(
-                                    builder: (context) => Home()
+                                Navigator.pushReplacement(context, PageRouteBuilder(
+                                  pageBuilder: (c, a1, a2) => Home(),
+                                  transitionsBuilder: (c, anim, a2, child) =>
+                                      FadeTransition(opacity: anim, child: child),
+                                  // transitionDuration: Duration(milliseconds: 1000),
                                 ));
                               },
                               showSkipButton: true,
                               skip: Text("Skip"),
                               onSkip: () {
                                 setFirstTime();
-                                Navigator.push(context, MaterialPageRoute(
-                                    builder: (context) => Home()
+                                Navigator.pushReplacement(context, PageRouteBuilder(
+                                  pageBuilder: (c, a1, a2) => Home(),
+                                  transitionsBuilder: (c, anim, a2, child) =>
+                                      FadeTransition(opacity: anim, child: child),
+                                  // transitionDuration: Duration(milliseconds: 1000),
                                 ));
                               },
                               done: const Text('Done', style: TextStyle(

--- a/lib/main.dart
+++ b/lib/main.dart
@@ -144,9 +144,12 @@ class _MyAppState extends State<MyApp> {
                                       ),
                                     ),
                                     image: Align(
-                                      child: Image.asset(
-                                          'assets/images/logo.png',
-                                          width: 350.0),
+                                      child: Padding(
+                                        padding: const EdgeInsets.fromLTRB(30, 0, 0, 0),
+                                        child: SvgPicture.asset(
+                                            'assets/images/doclenselight.svg',
+                                            width: 350.0),
+                                      ),
                                       alignment: Alignment.bottomCenter,
                                     )
                                 ),


### PR DESCRIPTION
### Fixes #124 

## Cause

The code used ```push``` instead of ```pushReplacement``` so the intro screen always remained the root screen. The code line 
```
Navigator.of(context).popUntil((route) => route.isFirst)
```
which is used to bring back the user to the root page (which should have been home) was bringing the user back to intro screen (because this was set as the root page).

## Changes

1. Replaced ```push``` with ```pushReplacement```
2. Replaced PNG with SVG

(MWoC and CWoC participant)