### PR TITLE
Fixed the bug associated with infinite duplicating of pictures in multi_select_delete page

### DIFF
--- a/lib/multi_select_delete.dart
+++ b/lib/multi_select_delete.dart
@@ -257,7 +257,21 @@ class _multiDeleteState extends State<multiDelete> {
 
   getAppBar() {
     return AppBar(
-      // backgroundColor: Colors.blue[600],
+      leading: IconButton(
+        onPressed: () {
+          if(itemList.length != 0){
+            setState(() {
+              widget.imageList.imagelist.removeAt(itemList.length - 1);
+              widget.imageList.imagepath.removeAt(itemList.length - 1);
+              itemList.removeAt(itemList.length - 1);
+            });
+          }
+          Navigator.of(context).pop();
+        },
+        icon: Icon(
+          Icons.arrow_back
+        ),
+      ),
       title: Text(selectedList.length < 1
           ? "Documents"
           : "${selectedList.length} item selected"),


### PR DESCRIPTION
Fixes #129 

Now when the user clicks the back button, the last image in the imageList and the itemList is removed and then when he presses the next button in Filterview, the same image is added back, therefore eliminating the duplicate image. 

If the user deletes all the images and decides to go back then all this is skipped and the user is directed back to Filterview.