### PR TITLE
Added starred documents screen and starring functionality

### DIFF
--- a/lib/Home.dart
+++ b/lib/Home.dart
@@ -205,11 +205,16 @@ class _HomeState extends State<Home> {
 
                                 List<dynamic> files = Hive.box('starred')
                                     .getAt(0);
-                                files.add('$path');
-                                Hive.box('starred').putAt(0, files);
-                                print(
-                                    "STARRED : ${Hive.box('starred').getAt(
-                                        0)}");
+                                if (files.contains(path)) {
+                                  Scaffold.of(context).showSnackBar(SnackBar(content: Text('Already a Starred document')));
+                                  print('Already fav');
+                                } else {
+                                  files.add('$path');
+                                  Hive.box('starred').putAt(0, files);
+                                  print(
+                                      "STARRED : ${Hive.box('starred').getAt(
+                                          0)}");
+                                }
                               },
                             )
                           ],

--- a/lib/Home.dart
+++ b/lib/Home.dart
@@ -197,7 +197,20 @@ class _HomeState extends State<Home> {
                                 icon: Icon(
                                   Icons.star_border
                                 ),
-                                onPressed: null,
+                              onPressed: () async {
+                                File file = await File(
+                                    pdfsBox.getAt(0)[index]
+                                );
+                                final path = file.path;
+
+                                List<dynamic> files = Hive.box('starred')
+                                    .getAt(0);
+                                files.add('$path');
+                                Hive.box('starred').putAt(0, files);
+                                print(
+                                    "STARRED : ${Hive.box('starred').getAt(
+                                        0)}");
+                              },
                             )
                           ],
                         )

--- a/lib/Home.dart
+++ b/lib/Home.dart
@@ -193,6 +193,12 @@ class _HomeState extends State<Home> {
                                 ),
                                 onPressed: () {}
                             ),
+                            IconButton(
+                                icon: Icon(
+                                  Icons.star_border
+                                ),
+                                onPressed: null,
+                            )
                           ],
                         )
                       ],

--- a/lib/Home.dart
+++ b/lib/Home.dart
@@ -97,6 +97,21 @@ class _HomeState extends State<Home> {
     ]);
   }
 
+  bool isStarred(pdfsBox, index) {
+    File file = File(
+        pdfsBox.getAt(0)[index]
+    );
+    final path = file.path;
+
+    List<dynamic> files = Hive.box('starred')
+        .getAt(0);
+    if(files.contains(path)){
+      return true;
+    } else {
+      return false;
+    }
+  }
+
   @override
   Widget build(BuildContext context) {
 //    return ChangeNotifierProvider.value(
@@ -195,9 +210,10 @@ class _HomeState extends State<Home> {
                             ),
                             IconButton(
                                 icon: Icon(
-                                  Icons.star_border
+                                  isStarred(pdfsBox, index) ? Icons.star : Icons.star_border,
                                 ),
                               onPressed: () async {
+                                  print(isStarred(pdfsBox, index));
                                 File file = await File(
                                     pdfsBox.getAt(0)[index]
                                 );
@@ -216,6 +232,9 @@ class _HomeState extends State<Home> {
                                           0)}");
                                   Scaffold.of(context).showSnackBar(SnackBar(content: Text('Added to starred documents!')));
                                 }
+                                setState(() {
+
+                                });
                               },
                             )
                           ],

--- a/lib/Home.dart
+++ b/lib/Home.dart
@@ -206,7 +206,7 @@ class _HomeState extends State<Home> {
                                 List<dynamic> files = Hive.box('starred')
                                     .getAt(0);
                                 if (files.contains(path)) {
-                                  Scaffold.of(context).showSnackBar(SnackBar(content: Text('Already a Starred document')));
+                                  Scaffold.of(context).showSnackBar(SnackBar(content: Text('Already a starred document')));
                                   print('Already fav');
                                 } else {
                                   files.add('$path');
@@ -214,6 +214,7 @@ class _HomeState extends State<Home> {
                                   print(
                                       "STARRED : ${Hive.box('starred').getAt(
                                           0)}");
+                                  Scaffold.of(context).showSnackBar(SnackBar(content: Text('Added to starred documents!')));
                                 }
                               },
                             )

--- a/lib/MainDrawer.dart
+++ b/lib/MainDrawer.dart
@@ -64,7 +64,18 @@ class MainDrawer extends StatelessWidget {
                   "Home",
                   style: TextStyle(fontSize: 18),)),
             ListTile(
-              onTap: () {},
+              onTap: () {
+                Navigator.of(context).pop();
+                // Navigator.push(
+                //   context,
+                //     PageRouteBuilder(
+                //       pageBuilder: (c, a1, a2) => Starred(),
+                //       transitionsBuilder: (c, anim, a2, child) =>
+                //           FadeTransition(opacity: anim, child: child),
+                //       // transitionDuration: Duration(milliseconds: 2000),
+                //     )
+                // );
+              },
               leading: Icon(Icons.stars_rounded),
               title: Text(
                 "Starred Documents",

--- a/lib/MainDrawer.dart
+++ b/lib/MainDrawer.dart
@@ -1,8 +1,8 @@
+import 'package:doclense/StarredDocuments.dart';
 import 'package:doclense/settings.dart';
 import 'package:flutter/material.dart';
 import 'package:flutter_svg/flutter_svg.dart';
 import 'package:provider/provider.dart';
-import 'Home.dart';
 import 'About.dart';
 import 'package:share/share.dart';
 import 'package:url_launcher/url_launcher.dart';
@@ -66,15 +66,15 @@ class MainDrawer extends StatelessWidget {
             ListTile(
               onTap: () {
                 Navigator.of(context).pop();
-                // Navigator.push(
-                //   context,
-                //     PageRouteBuilder(
-                //       pageBuilder: (c, a1, a2) => Starred(),
-                //       transitionsBuilder: (c, anim, a2, child) =>
-                //           FadeTransition(opacity: anim, child: child),
-                //       // transitionDuration: Duration(milliseconds: 2000),
-                //     )
-                // );
+                Navigator.push(
+                  context,
+                    PageRouteBuilder(
+                      pageBuilder: (c, a1, a2) => Starred(),
+                      transitionsBuilder: (c, anim, a2, child) =>
+                          FadeTransition(opacity: anim, child: child),
+                      // transitionDuration: Duration(milliseconds: 2000),
+                    )
+                );
               },
               leading: Icon(Icons.stars_rounded),
               title: Text(

--- a/lib/PDFConversion.dart
+++ b/lib/PDFConversion.dart
@@ -141,6 +141,7 @@ class _PDFConversion extends State<PDFConversion> {
           //         style: TextStyle(color: Colors.white),
           //       ));
           // } else
+          FocusScope.of(context).unfocus();
           _pushSaved();
         },
         child: Icon(

--- a/lib/StarredDocuments.dart
+++ b/lib/StarredDocuments.dart
@@ -1,0 +1,124 @@
+import 'package:flutter/cupertino.dart';
+import 'package:flutter/material.dart';
+import 'package:hive/hive.dart';
+import 'package:hive_flutter/hive_flutter.dart';
+import 'dart:io';
+import 'package:open_file/open_file.dart';
+import 'package:share/share.dart';
+import 'MainDrawer.dart';
+
+class Starred extends StatefulWidget {
+  @override
+  _StarredState createState() => _StarredState();
+}
+
+class _StarredState extends State<Starred> {
+  @override
+  Widget build(BuildContext context) {
+    return Scaffold(
+      drawer: MainDrawer(),
+      appBar: AppBar(
+        title: Text(
+          'Starred Docs',
+          style: TextStyle(
+              fontSize: 24),
+        ),
+        actions: <Widget>[
+          IconButton(
+            icon: Icon(Icons.refresh),
+            onPressed: () {
+              setState(() {
+              });
+            },
+          ),
+          IconButton(
+            icon: Icon(Icons.more_vert),
+            onPressed: () async {},
+          ),
+        ],
+      ),
+      body: WatchBoxBuilder(
+        box: Hive.box('starred'),
+        builder: (context, starredBox) {
+          if (starredBox
+              .getAt(0)
+              .length == 0) {
+            return Center(
+              child: Text(
+                  "No PDFs Starred Yet !! "
+              ),
+            );
+          }
+          return ListView.builder(
+            itemCount: starredBox
+                .getAt(0)
+                .length,
+            itemBuilder: (context, index) {
+              return GestureDetector(
+                onTap: () {
+                  print('tapped');
+                  OpenFile.open(starredBox.getAt(0)[index]);
+                },
+                child: Padding(
+                  padding: const EdgeInsets.all(15.0),
+                  child: Card(
+                    color: Colors.grey,
+                    child: Row(
+                      mainAxisAlignment: MainAxisAlignment.spaceAround,
+                      children: [
+                        Column(
+                          children: [
+                            Text(
+                                starredBox.getAt(0)[index]
+                                    .split('/')
+                                    .last
+                            ),
+                          ],
+                        ),
+                        Row(
+                          children: [
+                            IconButton(
+                                icon: Icon(
+                                    Icons.share
+                                ),
+                                onPressed: () async {
+
+                                  File file = await File(
+                                      starredBox.getAt(0)[index]
+                                  );
+
+                                  final path = file.path;
+
+                                  print(path);
+
+                                  Share.shareFiles(
+                                      ['$path'], text: 'Your PDF!');
+                                }
+                            ),
+                            IconButton(
+                                icon: Icon(
+                                    Icons.delete
+                                ),
+                                onPressed: () {}
+                            ),
+                            IconButton(
+                                icon: Icon(
+                                    Icons.star
+                                ),
+                                onPressed: () async {
+                                }
+                            )
+                          ],
+                        )
+                      ],
+                    ),
+                  ),
+                ),
+              );
+            },
+          );
+        },
+      ),
+    );
+  }
+}

--- a/lib/StarredDocuments.dart
+++ b/lib/StarredDocuments.dart
@@ -97,12 +97,6 @@ class _StarredState extends State<Starred> {
                             ),
                             IconButton(
                                 icon: Icon(
-                                    Icons.delete
-                                ),
-                                onPressed: () {}
-                            ),
-                            IconButton(
-                                icon: Icon(
                                     Icons.star
                                 ),
                                 onPressed: () async {

--- a/lib/main.dart
+++ b/lib/main.dart
@@ -21,6 +21,7 @@ Future<void> main() async {
   Hive.init(directory.path);
 
   await Hive.openBox('pdfs');
+  await Hive.openBox('starred');
   Hive.registerAdapter(UserPreferencesAdapter());
   final res = await Hive.openBox('preferences');
 
@@ -39,6 +40,14 @@ Future<void> main() async {
     final r = res.getAt(0);
   } on RangeError catch (e) {
     final res = await Hive.box('pdfs');
+    final r = res.add([]);
+  }
+
+  try {
+    final res = await Hive.box('starred');
+    final r = res.getAt(0);
+  } on RangeError catch (e) {
+    final res = await Hive.box('starred');
     final r = res.add([]);
   }
 


### PR DESCRIPTION
Closes #131 
Addressing #99 

## Additions
1. A new Hive box to store all the starred documents
2. Starred documents screen (similar to the home screen)
3. Option for starring from home screen (in every PDF's card widget)
4. Sharing option from the starred screen

## Things left to add
The un-starring option is something that needs to be implemented. It will be very similar to the delete option, but rather than deleting from ```pdfs``` box, the PDF will be deleted from ```starred``` box.
I have been trying but I haven't figured out how to delete the PDFs yet. Both these deleting features can be added in a single PR. After this PR is merged, I will open a separate issue for the delete function so that if someone can implement that, he/she can go ahead.

Please let me know if you want any changes in this PR. Thanks!

(MWoC and CWoC participant)