### PR TITLE
Fixed the bug associated with images not getting discarded even after the PDF is created

### DIFF
--- a/lib/PDFConversion.dart
+++ b/lib/PDFConversion.dart
@@ -69,6 +69,12 @@ class _PDFConversion extends State<PDFConversion> {
     print("PDFS : ${Hive.box('pdfs').getAt(0)}");
     //Directory documentDirectory = await getApplicationDocumentsDirectory();
 
+    // Clearing the image list once the PDF is created and saved
+    for (int i = 0; i < widget.list.imagelist.length; i++) {
+      print('i = $i');
+      widget.list.imagelist.removeAt(i);
+      widget.list.imagepath.removeAt(i);
+    }
     //String documentPath = documentDirectory.path;
 
     //File file = File("$documentPath/example.pdf");

--- a/lib/multi_select_delete.dart
+++ b/lib/multi_select_delete.dart
@@ -277,11 +277,10 @@ class _multiDeleteState extends State<multiDelete> {
         IconButton(
             icon: Icon(Icons.picture_as_pdf),
             onPressed: () {
-              ImageList finalImageList = widget.imageList;
               Navigator.push(
                   context,
                   PageRouteBuilder(
-                    pageBuilder: (c, a1, a2) => PDFConversion(finalImageList),
+                    pageBuilder: (c, a1, a2) => PDFConversion(widget.imageList),
                     transitionsBuilder: (c, anim, a2, child) =>
                         FadeTransition(opacity: anim, child: child),
                     // transitionDuration: Duration(milliseconds: 2000),

--- a/lib/multi_select_delete.dart
+++ b/lib/multi_select_delete.dart
@@ -277,16 +277,15 @@ class _multiDeleteState extends State<multiDelete> {
         IconButton(
             icon: Icon(Icons.picture_as_pdf),
             onPressed: () {
+              ImageList finalImageList = widget.imageList;
               Navigator.push(
                   context,
                   PageRouteBuilder(
-                    pageBuilder: (c, a1, a2) => PDFConversion(widget.imageList),
+                    pageBuilder: (c, a1, a2) => PDFConversion(finalImageList),
                     transitionsBuilder: (c, anim, a2, child) =>
                         FadeTransition(opacity: anim, child: child),
                     // transitionDuration: Duration(milliseconds: 2000),
                   ));
-              // MaterialPageRoute(
-              //     builder: (context) => PDFConversion(widget.imageList)));
             }),
         IconButton(
             icon: Icon(Icons.home),


### PR DESCRIPTION
Fixes #126 

I found the fix for this issue, now after the PDF is created and displayed the imageList is cleared in the ```savepdf``` function. Before this I was trying to clear the imageList once the pdf button in ```multi_select_delete``` was pressed which was resulting in yet another bug.

Please let me know if any changes are required. Thanks!

(MWoC and CWoC participant)