### PR TITLE
Fixed the bug associated with PDFs not getting removed from the Hive box even after deletion

### DIFF
--- a/lib/Home.dart
+++ b/lib/Home.dart
@@ -247,6 +247,8 @@ class _HomeState extends State<Home> {
                                                       setState(() {
                                                         pdfsBox.getAt(0)
                                                             .removeAt(index);
+                                                        List<dynamic> editedList = pdfsBox.getAt(0);
+                                                        pdfsBox.putAt(0, editedList);
                                                         if (starredFiles
                                                             .contains(
                                                             sourceFile.path)) {
@@ -264,6 +266,8 @@ class _HomeState extends State<Home> {
                                                                   'starred')
                                                                   .getAt(0)
                                                                   .removeAt(i);
+                                                              List<dynamic> editedList = Hive.box('starred').getAt(0);
+                                                              Hive.box('starred').putAt(0, editedList);
                                                               break;
                                                             }
                                                           }


### PR DESCRIPTION
Fixes #142 

## Changes
1. Now when the user clicks the delete button, a new list if created without the PDF which is deleted and then this list is put on the 0th location of the ```pdfs``` box, replacing the old error giving list.
2. The same thing is performed with the ```starred``` box.

Please let me know if any changes are required. Thanks!

(MWoC and CWoC participant)