### PR TITLE
add lint rules and github actions

### DIFF
--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -1,0 +1,22 @@
+name: "Flutter/Dart Lint Check"
+
+on: pull_request
+
+jobs:
+  lint-check:
+    name: Test on ${{ matrix.os }}
+    runs-on: ${{ matrix.os }}
+    strategy:
+        matrix:
+          os: [ubuntu-latest, windows-latest, macOS-latest]
+    steps:
+      - uses: actions/checkout@v2
+      - uses: actions/setup-java@v1
+        with:
+          java-version: '12.x'
+      - uses: subosito/flutter-action@v1
+        with:
+          channel: 'stable'
+      - run: flutter pub get
+      - name: Lint
+        run: flutter analyze

--- a/.gitignore
+++ b/.gitignore
@@ -30,6 +30,7 @@
 .pub-cache/
 .pub/
 /build/
+.fvm
 
 # Web related
 lib/generated_plugin_registrant.dart

--- a/analysis_options.yaml
+++ b/analysis_options.yaml
@@ -1,0 +1,16 @@
+include: package:lint/analysis_options.yaml
+
+analyzer:
+  errors: 
+    avoid_print: ignore
+
+    # below rules are changed from error to warning so source code doesn't break
+    argument_type_not_assignable: warning
+    invalid_assignment: warning
+    return_of_invalid_type_from_closure: warning
+
+
+  exclude:
+    - "**/*.gr.dart"
+    - "**/*.g.dart"
+    - "**/*.freezed.dart"

--- a/pubspec.lock
+++ b/pubspec.lock
@@ -436,6 +436,13 @@ packages:
       url: "https://pub.dartlang.org"
     source: hosted
     version: "3.1.1"
+  lint:
+    dependency: "direct dev"
+    description:
+      name: lint
+      url: "https://pub.dartlang.org"
+    source: hosted
+    version: "1.5.3"
   logging:
     dependency: transitive
     description:
@@ -932,5 +939,5 @@ packages:
     source: hosted
     version: "2.2.1"
 sdks:
-  dart: ">=2.12.0-0.0 <3.0.0"
+  dart: ">=2.12.0 <3.0.0"
   flutter: ">=1.24.0-10.1.pre"

--- a/pubspec.yaml
+++ b/pubspec.yaml
@@ -60,6 +60,7 @@ dev_dependencies:
     sdk: flutter
   hive_generator: ^0.8.2
   build_runner:
+  lint: ^1.0.0
 
 # For information on the generic Dart part of this file, see the
 # following page: https://dart.dev/tools/pub/pubspec


### PR DESCRIPTION
Fixes #152

### Changes
- Lint rules are added in analysis_options.yaml file. 
For now, some rules are changed from `error` to `warning`, so the source code can compile and run.

- A Github Action is added which analyzes dart/flutter according to the lint rules.

### Doubt
After adding lint rules, there are various info and warning in the source code. Should I create another issue to resolve them?
