### PR TITLE
Fix #163 : Pixel Overflow in Bottom Toolbar  

### DIFF
--- a/lib/Imageview.dart
+++ b/lib/Imageview.dart
@@ -108,7 +108,7 @@ class _ImageviewState extends State<Imageview> {
                 flex: (MediaQuery
                     .of(context)
                     .size
-                    .height / 19).floor(),
+                    .height / 18).floor(),
                 child: Container(
                   height: 65,
                   color: themeChange.darkTheme ? Colors.black87 : Colors.blue[600],
@@ -124,6 +124,7 @@ class _ImageviewState extends State<Imageview> {
 //                                      builder: (context) => Home()));
                           },
                           child: Column(
+                            mainAxisAlignment: MainAxisAlignment.spaceEvenly,
                             children: <Widget>[
                               Icon(
                                 Icons.arrow_back,
@@ -147,6 +148,7 @@ class _ImageviewState extends State<Imageview> {
                             }
                           },
                           child: Column(
+                            mainAxisAlignment: MainAxisAlignment.spaceEvenly,
                             children: <Widget>[
                               Icon(
                                 Icons.undo,
@@ -164,6 +166,7 @@ class _ImageviewState extends State<Imageview> {
                             cropimage(widget.file, appBarColor, bgColor);
                           },
                           child: Column(
+                            mainAxisAlignment: MainAxisAlignment.spaceEvenly,
                             children: <Widget>[
                               Icon(
                                 Icons.crop_rotate,
@@ -204,6 +207,7 @@ class _ImageviewState extends State<Imageview> {
                             }
                           },
                           child: Column(
+                            mainAxisAlignment: MainAxisAlignment.spaceEvenly,
                             children: <Widget>[
                               Icon(
                                 Icons.arrow_forward,


### PR DESCRIPTION
**Changes**

- Bottom Toolbar height increased , previously `h/19`now it is `h/18` using `MediaQuery`.
- `mainAxisAlignment: MainAxisAlignment.spaceEvenly` added in all the used `Column`.

Fixes [#163 ](https://github.com/smaranjitghose/DocLense/issues/163)



> Inspector is now looking good too.

![Screenshot_1615549188](https://user-images.githubusercontent.com/59207688/110935891-0ccb2c80-8356-11eb-8ee1-40691c3be10e.png)
