### PR TITLE
Fixed renderflex overflow in the bottom nav bar

### DIFF
--- a/lib/filter_view.dart
+++ b/lib/filter_view.dart
@@ -75,7 +75,7 @@ class _FilterimageState extends State<FilterImage> {
         child: Column(
           children: <Widget>[
             Expanded(
-              flex: (MediaQuery.of(context).size.height / 2).floor(),
+              flex: 7,
               child: Padding(
                 padding: const EdgeInsets.fromLTRB(20, 10, 20, 20),
                 child:
@@ -87,7 +87,6 @@ class _FilterimageState extends State<FilterImage> {
               ),
             ),
             Expanded(
-              flex: (MediaQuery.of(context).size.height / 16).floor(),
               child: Container(
                 height: 65,
                 color:
@@ -102,6 +101,7 @@ class _FilterimageState extends State<FilterImage> {
                           Navigator.of(context).pop();
                         },
                         child: Column(
+                          mainAxisAlignment: MainAxisAlignment.spaceEvenly,
                           children: const <Widget>[
                             Icon(
                               Icons.arrow_back,
@@ -119,6 +119,7 @@ class _FilterimageState extends State<FilterImage> {
                           getImage(context, appBarColor);
                         },
                         child: Column(
+                          mainAxisAlignment: MainAxisAlignment.spaceEvenly,
                           children: const <Widget>[
                             Icon(
                               Icons.filter,
@@ -149,6 +150,7 @@ class _FilterimageState extends State<FilterImage> {
                           );
                         },
                         child: Column(
+                          mainAxisAlignment: MainAxisAlignment.spaceEvenly,
                           children: const <Widget>[
                             Icon(
                               Icons.arrow_forward,

--- a/lib/image_view.dart
+++ b/lib/image_view.dart
@@ -104,7 +104,7 @@ class _ImageviewState extends State<Imageview> {
         child: Column(
           children: <Widget>[
             Expanded(
-              flex: (MediaQuery.of(context).size.height / 2).floor(),
+              flex: 7,
               child: Padding(
                 padding: const EdgeInsets.fromLTRB(20, 10, 20, 20),
                 child: Image.file(
@@ -113,7 +113,6 @@ class _ImageviewState extends State<Imageview> {
               ),
             ),
             Expanded(
-              flex: (MediaQuery.of(context).size.height / 18).floor(),
               child: Container(
                 height: 65,
                 color:


### PR DESCRIPTION
Closes #178 

## Screenshots

1. Pixel 2
<img src="https://user-images.githubusercontent.com/74055102/111690521-4b2f8280-8853-11eb-8796-8690ec0112a3.png" height="500px"
/>
2. Redmi note 5 pro
<img src="https://user-images.githubusercontent.com/74055102/111690590-669a8d80-8853-11eb-87be-8cc4f7d4eee5.jpg" height="500px"
/>

Please let me know if you want any changes in this PR, thanks!

(CWoC and GSSoC participant)