### PR TITLE
Reformated the starred PDF card

### DIFF
--- a/lib/Models/preferences.dart
+++ b/lib/Models/preferences.dart
@@ -1,4 +1,6 @@
 
+import 'dart:io';
+
 import 'package:hive/hive.dart';
 part 'preferences.g.dart';
 
@@ -10,6 +12,9 @@ class UserPreferences {
 
   @HiveField(1)
   bool darkTheme;
+
+  @HiveField(2)
+  File previewImage;
 
   UserPreferences({this.firstTime,this.darkTheme});
 }

--- a/lib/Models/preferences.g.dart
+++ b/lib/Models/preferences.g.dart
@@ -19,17 +19,19 @@ class UserPreferencesAdapter extends TypeAdapter<UserPreferences> {
     return UserPreferences(
       firstTime: fields[0] as bool,
       darkTheme: fields[1] as bool,
-    );
+    )..previewImage = fields[2] as File;
   }
 
   @override
   void write(BinaryWriter writer, UserPreferences obj) {
     writer
-      ..writeByte(2)
+      ..writeByte(3)
       ..writeByte(0)
       ..write(obj.firstTime)
       ..writeByte(1)
-      ..write(obj.darkTheme);
+      ..write(obj.darkTheme)
+      ..writeByte(2)
+      ..write(obj.previewImage);
   }
 
   @override

--- a/lib/home.dart
+++ b/lib/home.dart
@@ -559,6 +559,7 @@ class _HomeState extends State<Home> {
                                         .getAt(0)[index][0] as String);
                                     final path = file.path;
                                     final date = pdfsBox.getAt(0)[index][1];
+                                    final imagePreview = pdfsBox.getAt(0)[index][2];
 
                                     final List<dynamic> files =
                                         Hive.box('starred').getAt(0)
@@ -589,7 +590,7 @@ class _HomeState extends State<Home> {
                                                   'Removed from starred documents')));
                                       print('Already fav');
                                     } else {
-                                      files.add([path, date]);
+                                      files.add([path, date, imagePreview]);
                                       Hive.box('starred').putAt(0, files);
                                       print(
                                           "STARRED : ${Hive.box('starred').getAt(0)}");

--- a/lib/starred_documents.dart
+++ b/lib/starred_documents.dart
@@ -41,13 +41,17 @@ class _StarredState extends State<Starred> {
       body: WatchBoxBuilder(
         box: Hive.box('starred'),
         builder: (context, starredBox) {
-          if (starredBox.getAt(0).length == 0) {
+          if (starredBox
+              .getAt(0)
+              .length == 0) {
             return const Center(
               child: Text("No PDFs Starred Yet !! "),
             );
           }
           return ListView.builder(
-            itemCount: starredBox.getAt(0).length as int,
+            itemCount: starredBox
+                .getAt(0)
+                .length as int,
             itemBuilder: (context, index) {
               return GestureDetector(
                 onTap: () {
@@ -59,46 +63,81 @@ class _StarredState extends State<Starred> {
                   child: Card(
                     color: Colors.grey,
                     child: Row(
-                      mainAxisAlignment: MainAxisAlignment.spaceAround,
                       children: [
                         Column(
                           children: [
-                            Text((starredBox.getAt(0)[index][0] as String)
-                                .split('/')
-                                .last),
+                            Padding(
+                              padding: const EdgeInsets.all(8.0),
+                              child: Image(
+                                image: FileImage(
+                                    starredBox.getAt(0)[index][2] as File
+                                ),
+                                width: MediaQuery
+                                    .of(context)
+                                    .size
+                                    .width / 4,
+                              ),
+                            )
                           ],
                         ),
-                        Row(
+                        Column(
+                          crossAxisAlignment: CrossAxisAlignment.start,
                           children: [
-                            IconButton(
-                                icon: const Icon(Icons.share),
-                                onPressed: () async {
-                                  final File file = File(await starredBox
-                                      .getAt(0)[index][0] as String);
+                            Padding(
+                              padding: const EdgeInsets.all(8.0),
+                              child: Text(
+                                (starredBox.getAt(0)[index][0] as String)
+                                    .split('/')
+                                    .last,
+                                style: const TextStyle(fontSize: 18),
+                              ),
+                            ),
+                            Padding(
+                              padding: const EdgeInsets.fromLTRB(8, 0, 8, 8),
+                              child: Text('${starredBox.getAt(0)[index][1]}'),
+                            ),
+                            const SizedBox(
+                              height: 30,
+                            ),
 
-                                  final path = file.path;
+                            Row(
+                              children: [
+                                SizedBox(
+                                  width: MediaQuery.of(context).size.width/2.6,
+                                ),
+                                IconButton(
+                                    icon: const Icon(Icons.share),
+                                    onPressed: () async {
+                                      final File file = File(await starredBox
+                                          .getAt(0)[index][0] as String);
 
-                                  print(path);
+                                      final path = file.path;
 
-                                  Share.shareFiles([path], text: 'Your PDF!');
-                                }),
-                            IconButton(
-                                icon: const Icon(Icons.star),
-                                onPressed: () async {
-                                  setState(() {
-                                    Hive.box('starred')
-                                        .getAt(0)
-                                        .removeAt(index);
-                                  });
-                                  ScaffoldMessenger.of(context).showSnackBar(
-                                    const SnackBar(
-                                      content: Text(
-                                          'Removed from starred documents'),
-                                    ),
-                                  );
-                                })
+                                      print(path);
+
+                                      Share.shareFiles(
+                                          [path], text: 'Your PDF!');
+                                    }),
+                                IconButton(
+                                    icon: const Icon(Icons.star),
+                                    onPressed: () async {
+                                      setState(() {
+                                        Hive.box('starred')
+                                            .getAt(0)
+                                            .removeAt(index);
+                                      });
+                                      ScaffoldMessenger.of(context)
+                                          .showSnackBar(
+                                        const SnackBar(
+                                          content: Text(
+                                              'Removed from starred documents'),
+                                        ),
+                                      );
+                                    })
+                              ],
+                            )
                           ],
-                        )
+                        ),
                       ],
                     ),
                   ),


### PR DESCRIPTION
Closes #199 

## Changes
1. Passing preview image in starred box too now.
2. Displayed date and preview image in the starred PDF card.
3. Re-formatted the card to look like the card in home page but with only two features (un-starring and share PDF)

## Screenshot
<img src="https://user-images.githubusercontent.com/74055102/111753744-3a1b5b80-88bd-11eb-84a3-46d003b80f0d.png" height="500px"/>

Please let me know if you want any changes in this PR, thanks!

(CWoC and GSSoC participant)
