### PR TITLE
Fixed the bug associated with moving a PDF to another directory

### DIFF
--- a/android/app/src/main/AndroidManifest.xml
+++ b/android/app/src/main/AndroidManifest.xml
@@ -13,6 +13,7 @@
     <uses-permission android:name="android.permission.WRITE_EXTERNAL_STORAGE"/>
     <uses-permission android:name="android.permission.CAMERA"/>
     <application
+        android:requestLegacyExternalStorage="true"
         android:name="io.flutter.app.FlutterApplication"
         android:label="Doclense"
         android:icon="@mipmap/ic_launcher">

--- a/lib/home.dart
+++ b/lib/home.dart
@@ -15,6 +15,7 @@ import 'package:hive/hive.dart';
 import 'package:hive_flutter/hive_flutter.dart';
 import 'package:image_picker/image_picker.dart';
 import 'package:open_file/open_file.dart';
+import 'package:permission_handler/permission_handler.dart';
 import 'package:provider/provider.dart';
 import 'package:quick_actions/quick_actions.dart';
 import 'package:share/share.dart';
@@ -559,6 +560,10 @@ class _HomeState extends State<Home> {
                                           : Colors.grey,
                                     ),
                                     onPressed: () async {
+                                      final status = await Permission.storage.status;
+                                      if (!status.isGranted) {
+                                        await Permission.storage.request();
+                                      }
                                       final String oldPath =
                                           pdfsBox.getAt(0)[index][0] as String;
                                       String newPath;

--- a/lib/home.dart
+++ b/lib/home.dart
@@ -560,7 +560,7 @@ class _HomeState extends State<Home> {
                                     ),
                                     onPressed: () async {
                                       final String oldPath =
-                                          pdfsBox.getAt(0)[index] as String;
+                                          pdfsBox.getAt(0)[index][0] as String;
                                       String newPath;
                                       final String path = await ExtStorage
                                           .getExternalStorageDirectory();
@@ -575,7 +575,7 @@ class _HomeState extends State<Home> {
                                             action: (BuildContext context,
                                                 Directory folder) async {
                                               newPath =
-                                                  '${folder.path}/${(pdfsBox.getAt(0)[index] as String).split('/').last}';
+                                                  '${folder.path}/${(pdfsBox.getAt(0)[index][0] as String).split('/').last}';
                                               print(newPath);
                                               if (newPath != null) {
                                                 print("Newpath: $newPath");
@@ -584,7 +584,7 @@ class _HomeState extends State<Home> {
                                                 await sourceFile.copy(newPath);
                                                 await sourceFile.delete();
                                                 setState(() {
-                                                  pdfsBox.getAt(0)[index] =
+                                                  pdfsBox.getAt(0)[index][0] =
                                                       newPath;
                                                 });
                                               }


### PR DESCRIPTION
Fixes #164 

1. At the time of the creation of that issue, this feature was not working because of some permission issues.
2. After that, the storage style was changed to store the date of creation of the PDF and the preview image.

## Changes
Integrated this feature with the new storage style and surprisingly the bug went away:) (I still don't know why everyone was facing that issue before)

Please let me know if you want any changes in this PR, thanks!

(CWoC and GSSoC participant)
